### PR TITLE
CircleCI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,6 @@ jobs:
     steps:
       - checkout
       - run: chmod +x gradlew
-      - run: sudo add-apt-repository ppa:webupd8team/java
-      - run: sudo apt-get update
-      - run: sudo apt-get install oracle-java9-installer -y
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
Updates on CircleCI's end have broken the testing on JDK9. JDK8 will be used for testing untill JDK9 is avalible on CircleCI