### PR TITLE
Hotfix for CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Poly
 [![Codacy grade](https://img.shields.io/codacy/grade/0330000d284043f19a126cada035d410.svg?style=flat-square)](https://www.codacy.com/app/ponimansky.guy/Poly?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Voidustries/Poly&amp;utm_campaign=Badge_Grade)
-[![CircleCI](https://img.shields.io/circleci/project/github/Voidustries/Poly.svg?style=flat-square)](https://circleci.com/gh/Voidustries/Poly/tree/Gradle-Migration-For-CI)
+[![CircleCI](https://img.shields.io/circleci/project/github/Voidustries/Poly.svg?style=flat-square)](https://circleci.com/gh/Voidustries/Poly/tree/master)
 [![GitHub issues](https://img.shields.io/github/issues-raw/voidustries/poly.svg?style=flat-square)](https://github.com/Voidustries/Poly/issues)
 [![GitHub issues closed](https://img.shields.io/github/issues-closed-raw/voidustries/poly.svg?style=flat-square)](https://github.com/Voidustries/Poly/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/voidustries/poly.svg?style=flat-square)](https://github.com/Voidustries/Poly/pulls)


### PR DESCRIPTION
Fix issue #25

Wrong link was used in the Master readme, fixed so that correct badge for master is shown